### PR TITLE
Add support for client.once and include client in every event runner

### DIFF
--- a/bot/src/Logs.log
+++ b/bot/src/Logs.log
@@ -1,2 +1,0 @@
-{"level":"info","message":"18:function getMinutes() { [native code] } - 2:9:2023 | Info: Registered event guildMemberAdd (/home/endeavour/Code/dmcp/bot/src/events/guildMemberAdd.ts)"}
-{"level":"info","message":"18:function getMinutes() { [native code] } - 2:9:2023 | Info: Registered event interactionCreate (/home/endeavour/Code/dmcp/bot/src/events/interactionCreate.ts)"}

--- a/bot/src/events/guildMemberAdd.ts
+++ b/bot/src/events/guildMemberAdd.ts
@@ -1,7 +1,7 @@
 import { Event } from '../types';
 import axios from 'axios';
 
-const run: Event<'guildMemberAdd'> = async (member) => {
+const run: Event<'guildMemberAdd'> = async (client,member) => {
   if (member.user.bot) return;
 
   const res = await axios.put<{ id: string }>(

--- a/bot/src/types/event.ts
+++ b/bot/src/types/event.ts
@@ -1,5 +1,6 @@
 import { ClientEvents as DiscordClientEvents, ClientEvents } from 'discord.js';
 import { Interaction } from './discord';
+import { UsableClient } from '../client';
 
 export type UsableClientEvents = DiscordClientEvents & {
   interactionCreate: [Interaction];
@@ -7,6 +8,7 @@ export type UsableClientEvents = DiscordClientEvents & {
 
 export type ClientEvent = keyof UsableClientEvents;
 export type Event<Event extends ClientEvent> = (
+  client: UsableClient,
   ...args: UsableClientEvents[Event]
 ) => void;
 

--- a/bot/src/utils/registerEvents.ts
+++ b/bot/src/utils/registerEvents.ts
@@ -4,13 +4,15 @@ import fs from 'fs';
 import { removeExtension } from './file';
 
 export function registerEvents(client: UsableClient) {
-  const eventsPath = path.join(__dirname, "..", "events")
+  const eventsPath = path.join(__dirname, '..', 'events');
   fs.readdirSync(eventsPath)
     .filter((x) => x.endsWith('.ts'))
     .forEach((fileName) => {
       const event = require(`${eventsPath}/${fileName}`).default;
-      const eventName = removeExtension(fileName)
-      client.on(eventName, event.bind(client));
-      client.log(`Registered event ${eventName} (${eventsPath}/${fileName})`)
+      const eventName = removeExtension(fileName);
+      client[eventName.startsWith('$') ? 'once' : 'on'](eventName, (...args) =>
+        event.execute(client, ...args)
+      );
+      client.log(`Registered event ${eventName} (${eventsPath}/${fileName})`);
     });
 }


### PR DESCRIPTION
Fixes #5 - client will always be the first argument now(followed by the args provided by Discord.js)
Fixes #4 - to register an event with client.once you can prefix the file with '$'. (Example: $guildMemberAdd.ts)